### PR TITLE
Improved installation instructions

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -131,11 +131,11 @@ More information about Booktype deployment can be found in doc/deployment/ direc
 
    django-admin.py createsuperuser
 
-10. Add common dokumentation licenses 
+10. Add common documentation licenses
 
    django-admin.py loaddata documentation_licenses
 
-11. Start the whole thing. 
+11. Start the whole thing.
 
    django-admin.py runserver 0.0.0.0:8000
 


### PR DESCRIPTION
I've made some [minor] improvements to the installation instructions, namely calling out the dependency on the Python Imaging Library, and removing an extra "and" in an installation command.
