### PR TITLE
BK-1122 Wrong links since removing the old reader app

### DIFF
--- a/lib/booki/editor/urls.py
+++ b/lib/booki/editor/urls.py
@@ -27,6 +27,6 @@ urlpatterns = patterns('',
 
                         # book editing
                         url(r'^_edit/$', 'booki.editor.views.edit_book', name='edit_book'),
-                        url(r'^_edit/static/(?P<attachment>.*)$', 'booki.reader.views.staticattachment'),
+                        url(r'^_edit/static/(?P<attachment>.*)$', 'booktype.apps.core.views.staticattachment'),
                         url(r'^_edit/book-list.json$', 'booki.editor.views.view_books_autocomplete'),
                       )       

--- a/lib/booktype/apps/account/templates/account/dashboard_book_template.html
+++ b/lib/booktype/apps/account/templates/account/dashboard_book_template.html
@@ -2,7 +2,7 @@
 <div class="grid-4">
     <figure class="custom-cover">
         {% if book.cover %}
-            <img src="{% url "book_info" book.url_title %}cover.jpg" />
+            <img src="{% url "reader:book_cover" book.url_title %}" />
         {% else %}
             <img src="{% static "core/img/thumb-default.png" %}"/>
         {% endif %}

--- a/lib/booktype/apps/importer/views.py
+++ b/lib/booktype/apps/importer/views.py
@@ -76,7 +76,7 @@ def frontpage(request):
 
             from django.core.urlresolvers import reverse
 
-            res = HttpResponseRedirect(reverse('book_info', kwargs={'bookid': book.url_title})) # Redirect after POST
+            res = HttpResponseRedirect(reverse('reader:infopage', kwargs={'bookid': book.url_title})) # Redirect after POST
 
             return res
 

--- a/lib/booktype/apps/portal/templates/portal/books.html
+++ b/lib/booktype/apps/portal/templates/portal/books.html
@@ -30,7 +30,7 @@
                                 <div class="grid-4">
                                     <figure class="custom-cover">
                                         {% if book.cover %}
-                                            <img src="{% url "book_info" book.url_title %}cover.jpg" />
+                                            <img src="{% url "reader:book_cover" book.url_title %}" />
                                         {% else %}
                                             <img src="{% static "core/img/thumb-default.png" %}"/>
                                         {% endif %}
@@ -81,7 +81,7 @@
                             <li>
                                 <figure>
                                     {% if book.cover %}
-                                        <img src="{% url "book_info" book.url_title %}cover.jpg" />
+                                        <img src="{% url "reader:book_cover" book.url_title %}" />
                                     {% else %}
                                         <img src="{% static "core/img/list-default.png" %}"/>
                                     {% endif %}
@@ -99,7 +99,7 @@
                             <li>
                                 <figure>
                                         {% if book.cover %}
-                                            <img src="{% url "book_info" book.url_title %}cover.jpg" />
+                                            <img src="{% url "reader:book_cover" book.url_title %}" />
                                         {% else %}
                                             <img src="{% static "core/img/list-default.png" %}"/>
                                         {% endif %}

--- a/lib/booktype/apps/portal/templates/portal/frontpage.html
+++ b/lib/booktype/apps/portal/templates/portal/frontpage.html
@@ -28,7 +28,7 @@
                                 <div class="grid-2">
                                     <figure class="custom-cover">
                                         {% if book.cover %}
-                                            <img src="{% url "book_info" book.url_title %}cover.jpg" />
+                                            <img src="{% url "reader:book_cover" book.url_title %}" />
                                         {% else %}
                                             <img src="{% static "core/img/thumb-default.png" %}"/>
                                         {% endif %}

--- a/lib/booktype/apps/portal/templates/portal/group.html
+++ b/lib/booktype/apps/portal/templates/portal/group.html
@@ -53,13 +53,13 @@
                             <div class="grid-4">
                                 <figure class="custom-cover">
                                     {% if book.cover %}
-                                        <img src="{% url "book_info" book.url_title %}cover.jpg" />
+                                        <img src="{% url "reader:book_cover" book.url_title %}" />
                                     {% else %}
                                         <img src="{% static "core/img/thumb-default.png" %}"/>
                                     {% endif %}
                                 </figure>
                                 <div class="book-info">
-                                    <h4><a href="{% url "book_info" book.url_title %}">{{ book.title }}</a></h4>
+                                    <h4><a href="{% url "reader:infopage" book.url_title %}">{{ book.title }}</a></h4>
                                         {% if request.user.is_authenticated %}
                                             <div class="btn-group float-right">
                                                 <a class="btn btn-xs" rel="tooltip" title="" data-placement="bottom" data-original-title="{% trans "Edit Book" %}" data-toggle="modal" href="{% url "edit:editor" book.url_title %}"><i class="icon-pencil"></i></a>

--- a/lib/booktype/apps/portal/templates/portal/portal_add_book_modal.html
+++ b/lib/booktype/apps/portal/templates/portal/portal_add_book_modal.html
@@ -18,13 +18,13 @@
                                 <div class="grid-4">
                                     <figure class="custom-cover">
                                         {% if book.cover %}
-                                            <img src="{% url "book_info" book.url_title %}cover.jpg" />
+                                            <img src="{% url "reader:book_cover" book.url_title %}" />
                                         {% else %}
                                             <img src="{% static "core/img/thumb-default.png" %}"/>
                                         {% endif %}
                                     </figure>
                                     <div class="book-info">
-                                        <h4><a href="{% url "book_info" book.url_title %}">{{ book.title }}</a></h4>
+                                        <h4><a href="{% url "reader:infopage" book.url_title %}">{{ book.title }}</a></h4>
                                     </div>
                                 </div>
                                 <input type="checkbox" class="selected-book" value="{{ book.url_title }}">                            

--- a/lib/booktype/apps/reader/templates/reader/book_info_edit.html
+++ b/lib/booktype/apps/reader/templates/reader/book_info_edit.html
@@ -3,7 +3,7 @@
 <div class="modal-dialog">
     <div class="modal-content">
         <iframe name="hidden_frame" style="border: 0px; width: 0px; height: 0px"></iframe>
-        <form method="post" action="{% url "edit_info" book.url_title %}" target="hidden_frame" enctype="multipart/form-data" style="margin-bottom: 0px">
+        <form method="post" action="{% url "reader:edit_info_book" book.url_title %}" target="hidden_frame" enctype="multipart/form-data" style="margin-bottom: 0px">
             <div class="modal-header"><h4 class="modal-title">{% trans "Edit Book Info" %}</h4></div>
             <div class="modal-body">                                
                 {% csrf_token %}

--- a/lib/booktype/apps/reader/templates/reader/book_info_page.html
+++ b/lib/booktype/apps/reader/templates/reader/book_info_page.html
@@ -10,7 +10,13 @@
     <div class="row two-col">
         <div class="col-xs-8">
             <div class="box profile-box black">
-                <figure><img src="http://lorempixel.com/240/368/technics"></figure>
+                <figure>
+                    {% if book.cover %}
+                        <img src="{% url "reader:book_cover" book.url_title %}" />
+                    {% else %}
+                        <img src="{% static "core/img/thumb-default.png" %}"/>
+                    {% endif %}
+                </figure>
                 <div class="list-info">
                   <h2 class="box-title">{{ book.title }}</h2>
 

--- a/lib/booktype/apps/reader/urls.py
+++ b/lib/booktype/apps/reader/urls.py
@@ -17,10 +17,11 @@
 from django.conf.urls import patterns, url, include
 
 from .views import InfoPageView, DeleteBookView, EditBookInfoView
-from .views import DraftChapterView, FullView
+from .views import DraftChapterView, FullView, BookCoverView
 
 urlpatterns = patterns('',
    url(r'^_info/$', InfoPageView.as_view(), name='infopage'),
+   url(r'^_info/cover.jpg$', BookCoverView.as_view(), name='book_cover'),
    url(r'^_info/edit/$', EditBookInfoView.as_view(), name='edit_info_book'),
    url(r'^_info/delete/$', DeleteBookView.as_view(), name='delete_book'),
    url(r'^_full/$', FullView.as_view(), name='full_view'),

--- a/lib/booktype/apps/reader/views.py
+++ b/lib/booktype/apps/reader/views.py
@@ -16,18 +16,20 @@
 
 import os
 
+from django.views import static
+from django.conf import settings
+from django.contrib.auth.models import User
 from django.http import HttpResponseForbidden
 from django.shortcuts import get_object_or_404
-from django.contrib.auth.models import User
-from django.views.generic import DetailView, DeleteView, UpdateView
 from django.utils.translation import ugettext_lazy as _
+from django.views.generic import DetailView, DeleteView, UpdateView
 
 from braces.views import LoginRequiredMixin
 
 from booki.utils import misc, security
 from booki.utils.book import removeBook
-from booki.editor.models import Book, BookHistory, BookToc, Chapter
 from booktype.apps.core.views import BasePageView
+from booki.editor.models import Book, BookHistory, BookToc, Chapter
 
 class BaseReaderView(object):
     """
@@ -156,3 +158,17 @@ class FullView(BaseReaderView, BasePageView, DetailView):
         context['toc_items'] = toc_items
 
         return context
+
+class BookCoverView(BaseReaderView, DetailView):
+    """
+    Simple DetailView inherit clase to serve the book cover image
+    """
+
+    http_method_names = [u'get']
+    
+    def render_to_response(self, context, **response_kwargs):
+        """
+        Override render_to_response to serve the book cover static image
+        """
+
+        return static.serve(self.request, self.object.cover.name, settings.MEDIA_ROOT)

--- a/lib/booktypecontrol/templates/booktypecontrol/book.html
+++ b/lib/booktypecontrol/templates/booktypecontrol/book.html
@@ -12,7 +12,7 @@
     });
 
     $("button[name=bookinfo]").click(function() {
-       window.location = '{% url "book_info" book.url_title %}';
+       window.location = '{% url "reader:infopage" book.url_title %}';
     });
 
     $("button[name=edit]").click(function() {
@@ -55,7 +55,7 @@
   </div>
  {% endif %}
 
- <div class="book-cover">{% if book.cover %}<img src="{% url "book_info" book.url_title %}cover.jpg"/>{% endif %}</div>
+ <div class="book-cover">{% if book.cover %}<img src="{% url "reader:book_cover" book.url_title %}"/>{% endif %}</div>
  <p class="book-description">{{ book_description|safe }}</p>
  <p style="clear:both; margin-top:0;">&nbsp;</p>
 


### PR DESCRIPTION
Since we removed the old reader application some links got broken. This task contains a subtask related with the book cover image:
- https://dev.sourcefabric.org/browse/BK-1123

We needed a view to serve the book cover as legacy reader did. BK-1123 subtask is included in same commit because it was a little change and also it is a dependency of the main task.
