### PR TITLE
Bk-1037 Missing modal window for "Create New Group" button

### DIFF
--- a/lib/booktype/apps/portal/templates/portal/group_create_modal.html
+++ b/lib/booktype/apps/portal/templates/portal/group_create_modal.html
@@ -3,6 +3,7 @@
 <div class="modal-dialog">
     <div class="modal-content">
         <div class="modal-header">
+            <button type="button" class="close" data-dismiss="modal" aria-hidden="true">×</button>
             <h2 class="modal-title" id="myModalLabel">{% trans "Create a new group" %}</h2>
         </div>
         <form method="post" action="{% url 'portal:group_create' %}"  enctype="multipart/form-data" style="margin-bottom: 0px">


### PR DESCRIPTION
Just added a close button to the Create Group modal window
