### PR TITLE
BK-1167 Fix style of Booktype text logo

### DIFF
--- a/lib/booktype/apps/core/static/core/css/bt20.css
+++ b/lib/booktype/apps/core/static/core/css/bt20.css
@@ -61,3 +61,12 @@ input[type="radio"].form-control:focus{
 .book-list > div:hover .control_center_btns{
     display: none;
 }
+
+.logotext{
+    font-size: 17px;
+    line-height: 40px;
+    padding-left: 78px;
+}
+.logotext a{
+    color: #fff;
+}


### PR DESCRIPTION
If admin user changes the site title in control center the app replace the Booktype's logo with the desired text. This text has no style or a good font-type
