### PR TITLE
BK-1181 License management in Control Center is missing remove feature

### DIFF
--- a/lib/booktype/apps/core/static/core/css/bt20.css
+++ b/lib/booktype/apps/core/static/core/css/bt20.css
@@ -75,3 +75,9 @@ input[type="radio"].form-control:focus{
     padding-left: 20px;
     padding-right: 20px;
 }
+
+.license-delete{
+    position: relative;
+    top: -60px;
+    left: 428px;
+}

--- a/lib/booktypecontrol/templates/booktypecontrol/_control_center_license_edit.html
+++ b/lib/booktypecontrol/templates/booktypecontrol/_control_center_license_edit.html
@@ -2,6 +2,10 @@
 {% load i18n %}
 
 {% block extra_cc_content %}
+    <button class="btn btn-primary license-delete" data-remote="{% url 'control_center:delete_license' license.pk %}" data-toggle="modal" data-target="#bookEditModal">
+        {% trans "Remove" %}
+    </button>
+
     <h4 class="border-bottom">{% trans "Books licensed with" %} "{{ license.name }}"</h4>
     {% url 'control_center:settings' as next %}
     {% with next|add:"?redirect=list-of-books" as next %}

--- a/lib/booktypecontrol/templates/booktypecontrol/_control_center_modal_delete_license.html
+++ b/lib/booktypecontrol/templates/booktypecontrol/_control_center_modal_delete_license.html
@@ -1,0 +1,24 @@
+{% load i18n %}
+<div class="modal-dialog">
+    <div class="modal-content">
+        <form action="{% url 'control_center:delete_license' license.pk %}" method='POST'>
+            {% csrf_token %}
+            <div class="modal-header">
+                <h4 class="modal-title">{% trans "Delete License" %}</h4>
+            </div>
+            <div class="modal-body">
+                <p>
+                {% if license.book_set.all %}
+                    {% trans "There are licensed books with this license. You should change the license for these books before deleting it." %}
+                {% else %}
+                    {% trans "Are you sure you would like to delete this license? You will not be able to undo this operation!" %}
+                {% endif %}
+                </p>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-default" data-dismiss="modal">{% trans "Cancel" %}</button>
+                <button type="submit" class="btn btn-primary delete-book"{% if license.book_set.all %} disabled{% endif %}>{% trans "Delete License" %}</button>
+            </div>
+        </form>
+    </div>
+</div>

--- a/lib/booktypecontrol/urls.py
+++ b/lib/booktypecontrol/urls.py
@@ -18,7 +18,7 @@ from django.conf.urls import patterns, url
 
 from .views import (ControlCenterView, ControlCenterSettings, PersonInfoView,
                     EditPersonInfo, PasswordChangeView, BookRenameView, DeleteGroupView,
-                    LicenseEditView)
+                    LicenseEditView, DeleteLicenseView)
 
 urlpatterns = patterns('',
     url(r'^$', ControlCenterView.as_view(), name='frontpage'),
@@ -31,4 +31,5 @@ urlpatterns = patterns('',
     url(r'^books/(?P<bookid>[\w\s\_\.\-\d]+)/rename/$', BookRenameView.as_view(), name='rename_book'),
     url(r'^groups/(?P<groupid>[\w\s\_\.\-\d]+)/delete/$', DeleteGroupView.as_view(), name='delete_group'),
     url(r'^licenses/(?P<pk>\d+)/edit/$', LicenseEditView.as_view(), name="license_edit"),
+    url(r'^licenses/(?P<pk>\d+)/delete/$', DeleteLicenseView.as_view(), name="delete_license"),
 )

--- a/lib/booktypecontrol/views.py
+++ b/lib/booktypecontrol/views.py
@@ -348,3 +348,20 @@ class LicenseEditView(BaseCCView, UpdateView):
     def get_success_url(self):
         messages.success(self.request, _('License successfully updated.'))
         return "%s#license" % reverse('control_center:settings')
+
+class DeleteLicenseView(BaseCCView, DeleteView):
+    model = License
+    context_object_name = 'license'
+    template_name = 'booktypecontrol/_control_center_modal_delete_license.html'
+
+    def delete(self, request, *args, **kwargs):
+        self.object = self.get_object()
+        if self.object.book_set.all():
+            messages.warning(self.request, _('There are licensed books with this license. Unable to remove'))
+            return HttpResponseRedirect(self.get_success_url())
+        else:
+            messages.success(self.request, _('License successfully deleted.'))
+        return super(DeleteLicenseView, self).delete(request, *args, **kwargs)
+
+    def get_success_url(self):
+        return "%s#license" % reverse('control_center:settings')


### PR DESCRIPTION
License management in Control Center is missing remove feature. I just added a confirmation modal window and validated if license doesn't has licensed books with it
