### PR TITLE
BK-1214 Big images will overflow the container in the book view

### DIFF
--- a/lib/booktype/apps/core/static/core/css/bt20.css
+++ b/lib/booktype/apps/core/static/core/css/bt20.css
@@ -99,3 +99,9 @@ input[type="radio"].form-control:focus{
 .group-list h4{
     margin-right: 135px;
 }
+ 
+#bookcontent img,
+#bookcontent table{
+    max-width: 100%;
+    height: auto;
+}


### PR DESCRIPTION
Images inside draft view and full book view, now adjust to container. For the case of tables, also have the adjustment, but it depends of the numbers of column and how the table html is created.
