### PR TITLE
BK-1260 Fix broken footer link to Booktype Pro, remove 'free', add link to manual

### DIFF
--- a/lib/booktype/apps/core/templates/core/footer.html
+++ b/lib/booktype/apps/core/templates/core/footer.html
@@ -6,14 +6,14 @@
       {% comment %} Footer info. {% endcomment %}
       <h2>{% trans "About" %}</h2>
       {% comment %} Description what is Booktype in the footer.{% endcomment %}      
-      <p>{% blocktrans %}This is a demonstration server for Booktype. This server is reset on a regular basis, and any books created here will be deleted at that time. {% endblocktrans %}</p>
+      <p>{% blocktrans %}This is a demonstration server for Booktype. This server is reset on a regular basis, and any books created here will be deleted at that time. You can read the Booktype user manual at <a href="http://sourcefabric.booktype.pro/booktype-20-for-authors-and-publishers/">http://sourcefabric.booktype.pro/booktype-20-for-authors-and-publishers/</a>.{% endblocktrans %}</p>
     </div>
 
     <div class="col-xs-4">
       {% comment %} Footer info. {% endcomment %}    
       <h2>{% trans "How to use" %}</h2>
       {% comment %} Description how to use Booktype in the footer.{% endcomment %}            
-      <p>{% blocktrans %}If you wish to have your own installation please either download the sources <a href="http://www.sourcefabric.org/en/booktype/">http://www.sourcefabric.org/en/booktype/</a> or check out Booktype Pro, our free, cloud-hosted publishing service - <a href="http://sourcefabric.com/en/booktypepro/">http://sourcefabric.com/en/booktypepro/</a>.{% endblocktrans %}</p>
+      <p>{% blocktrans %}If you wish to have your own installation please download Booktype from <a href="http://www.sourcefabric.org/en/booktype/">http://www.sourcefabric.org/en/booktype/</a> or check out Booktype Pro, our cloud-hosted publishing service - <a href="http://booktype.pro/">http://booktype.pro/</a>.{% endblocktrans %}</p>
     </div>
 
     <div class="col-xs-4">


### PR DESCRIPTION
Fixing a few issues with the default footer template which appears on demo sites.
