### PR TITLE
BK-1267 Django migration is broken with license model changes

### DIFF
--- a/lib/booki/editor/migrations/0017_auto__add_field_license_url.py
+++ b/lib/booki/editor/migrations/0017_auto__add_field_license_url.py
@@ -10,8 +10,9 @@ class Migration(SchemaMigration):
     def forwards(self, orm):
         # Adding field 'License.url'
         db.add_column(u'editor_license', 'url',
-                      self.gf('django.db.models.fields.URLField')(default='', max_length=200, blank=True),
-                      keep_default=False)
+            self.gf('django.db.models.fields.URLField')(default='', max_length=200, blank=True, null=True),
+            keep_default=False
+        )
 
 
     def backwards(self, orm):

--- a/scripts/before_pull_request.sh
+++ b/scripts/before_pull_request.sh
@@ -101,7 +101,7 @@ function git_changes {
 
      if [[ $line == *.py ]]; then
 
-       CHANGES=$( pep8 -qq --count --ignore=E501 --exclude=migrations "${BOOKTYPE_INSTALL}${FILE_NAME}" 2>&1 )
+       CHANGES=$( pep8 -qq --count --ignore=E501 --exclude='*migrations*' "${BOOKTYPE_INSTALL}${FILE_NAME}" 2>&1 )
 
        if [[ $CHANGES -gt 0 ]]; then
          echo "    [PEP8]   ${BOOKTYPE_INSTALL}${FILE_NAME}"


### PR DESCRIPTION
This fix the problem when running the migrations on a new instance of Booktype 2.0. I did a little fix to the before_pull_request.sh script because it was taking in account the migration files.
