### PR TITLE
BK-1294 Delete permissions with update_permissions sync command

### DIFF
--- a/lib/booktype/apps/core/management/commands/update_permissions.py
+++ b/lib/booktype/apps/core/management/commands/update_permissions.py
@@ -1,10 +1,15 @@
 # -*- coding: utf-8 -*-
-from django.core.management.base import BaseCommand
+from optparse import make_option
 from django.conf import settings
+from django.core.management.base import BaseCommand
 
+from booktype.apps.core.models import Permission
 from booktype.utils.permissions import (
     create_permissions, permissions_for_app
 )
+
+# this is to print yellow color messages in terminal
+WARNING = '\033[93m'
 
 
 class Command(BaseCommand):
@@ -13,7 +18,31 @@ class Command(BaseCommand):
 
     # TODO: load permissions just for one app specified as param
 
+    option_list = BaseCommand.option_list + (
+        make_option(
+            '--delete-orphans', action='store_true',
+            help='Specify this param to delete undeclared permissions'
+        ),
+    )
+
     def handle(self, *args, **options):
+        saved_perms = []
+
         for app_name in settings.INSTALLED_APPS:
-            perms = permissions_for_app(app_name)
-            create_permissions(app_name, perms)
+            app_perms = permissions_for_app(app_name)
+            saved_perms += create_permissions(app_name, app_perms)
+
+        saved_perms_ids = [p.pk for p in saved_perms]
+        orphan_perms = Permission.objects.exclude(id__in=saved_perms_ids)
+
+        if options['delete_orphans']:
+            orphan_perms.delete()
+            print WARNING + "All undeclared permissions has been deleted."
+        else:
+            if orphan_perms.count() > 0:
+                suggestion = (
+                    "There are %s undeclared permissions. "
+                    "To delete them use: \n"
+                    "./manage.py update_permissions --delete-orphans"
+                )
+                print WARNING + suggestion % orphan_perms.count()

--- a/lib/booktype/utils/permissions.py
+++ b/lib/booktype/utils/permissions.py
@@ -11,12 +11,16 @@ def create_permissions(app_name, app_perms):
     Args:
         app_name: Booktype application module
         app_perms: List of tuples with the permissions to be registered
+
+    Returns:
+        A list with all saved permissions
     """
 
     perms_app_name = app_perms.get('app_name', app_name)
     permissions = app_perms.get('permissions', None)
+    created_perms = []
     if not permissions:
-        return None
+        return created_perms
 
     if len(permissions) > 0:
         print "Updating permissions for %s" % app_name
@@ -28,8 +32,11 @@ def create_permissions(app_name, app_perms):
         )
         perm.description = unicode(description)
         perm.save()
+        created_perms.append(perm)
         print "\t- saving %s.%s permission".expandtabs(4) \
             % (perms_app_name, codename)
+
+    return created_perms
 
 
 def permissions_for_app(app_name):


### PR DESCRIPTION
Now we have the alternative to pass --delete-orphans params to update_permissions command to delete old unneeded or undeclared permissions. :)
