### PR TITLE
BK-695 Chapter status do not save when editing name

### DIFF
--- a/lib/booki/site_static/js/editor.js
+++ b/lib/booki/site_static/js/editor.js
@@ -1860,8 +1860,19 @@ $(function() {
 					var i = $(this).attr("name");
 					var nm = getStatusDescription(i);
 					var ns = prompt($.booki._('new_status_name', "New status name"), nm);
-					if(ns) {
-					    dial.find("#liststatus_"+i+" .statuslabel").html(escapeJS(ns));
+					if(ns && ns != nm) {
+						$.booki.sendToCurrentBook({'command': 'book_status_rename',
+						    'status_id': i, "status_name": ns}, 
+					    function(data) {
+						if(data.result == false) {
+						    alert($.booki._('cant_rename_status', "There was an error renaming the status."));
+						} else {
+						    // send event
+						    statuses = data.statuses;
+						    dial.find("#liststatus_"+i+" .statuslabel").html(escapeJS(ns));
+						}
+					    });
+					    
 					}
 				    });
 			    }


### PR DESCRIPTION
The edit button for chapter status in the settings now sends the sputnik
command "remote_book_status_rename" instead of just modifying the HTML.

The "remote_book_status_rename" command is now implemented in the
booki editor channel.
