### PR TITLE
BK-2260 Add paper sizes used by IDEA to constants

### DIFF
--- a/lib/booktype/convert/pdf/constants.py
+++ b/lib/booktype/convert/pdf/constants.py
@@ -46,6 +46,9 @@ PAGE_SIZE_DATA = {
     "US5x8":          {'page_width': 5 * INCH_2_POINT, 'page_height': 8 * INCH_2_POINT},
     "US7x10":         {'page_width': 7 * INCH_2_POINT, 'page_height': 10 * INCH_2_POINT},
 
+    "Swedish Report": {'page_width': 165 * MM_2_POINT, 'page_height': 242 * MM_2_POINT},
+    "UK Report":      {'page_width': 170 * MM_2_POINT, 'page_height': 244 * MM_2_POINT},
+
     "A5":             {'page_width': 148 * MM_2_POINT, 'page_height': 210 * MM_2_POINT},
     "A4":             {'page_width': 210 * MM_2_POINT, 'page_height': 297 * MM_2_POINT},
     "A3":             {'page_width': 297 * MM_2_POINT, 'page_height': 420 * MM_2_POINT},


### PR DESCRIPTION
Adding these to constants so users needing these paper sizes don't have to choose 'Custom' paper sizes every time. These settings are optional in the template edit/panel_publish.html on the instance.