### PR TITLE
BK-2435 ContentCleanUpPlugin sometimes removes valid content

### DIFF
--- a/lib/booktype/convert/epub/writerplugins/content_cleanup_plugin.py
+++ b/lib/booktype/convert/epub/writerplugins/content_cleanup_plugin.py
@@ -41,18 +41,20 @@ class ContentCleanUpPlugin(BasePlugin):
         # walk over all elements in the tree and remove all
         # nodes that are recursively empty
         body = root.find('body')
-        for elem in body.xpath("//*"):
+
+        for elem in body.xpath("//body//*"):
             # remove not wanted attributes
             for attr in attrs_to_remove_on_cleanup:
                 if attr in elem.attrib:
                     del elem.attrib[attr]
 
-            parent = elem.getparent()
             klasses = elem.get('class', '').split()
             allowed_by_class = any([x in allowed_empty_by_classes for x in klasses])
 
             if recursively_empty(elem) and elem.tag not in tags_allowed_to_be_empty and not allowed_by_class:
-                parent.remove(elem)
+                # just in case if text contains spaces or tabs, because drop_tag removes only tag
+                elem.text = ''
+                elem.drop_tag()
 
         chapter.content = etree.tostring(root, pretty_print=True, encoding="utf-8", xml_declaration=True)
 


### PR DESCRIPTION
Hi @eos87 ,
This pr is about how sweet lxml is :)

> ```python
> for elem in body.xpath("//*"):
> ```

I would expect lxml walk through objects inside body (I hope you also expected it), but it does not. It walks starting from the root (html element), which is wrong for us. Check a screenshot from my debugger: 
![screen shot 2018-01-30 at 12 09 47](https://user-images.githubusercontent.com/4199922/35569758-51e2e06a-05cd-11e8-9e28-1e654feb011d.png)
Here you can see what result gives `body.xpath("//*")` in our context.


```python
parent.remove(elem)
```
Here we see another lxml's feature. When we execute this command, lxml removes element, let's say an empty `<a>` and a content after it which belongs to parent. See a screenshot.
<img width="1111" alt="screen shot 2018-01-30 at 15 00 39" src="https://user-images.githubusercontent.com/4199922/35570142-97f89f08-05ce-11e8-97f3-ce43810ae2ce.png">
In this context elem is a reference to an empty `<a>` tag which is inside `<p>`, lxml removes an empty tag and rest of the content after it in context of parent's `<p>`. 

Please, test this pr with cases ContentCleanUpPlugin was developed for 🍺 🍺 🍺 



