### PR TITLE
BK-2466 Rename all inserted images in chapters during image file renaming in media library

### DIFF
--- a/lib/booktype/apps/edit/static/edit/js/booktype/editor.js
+++ b/lib/booktype/apps/edit/static/edit/js/booktype/editor.js
@@ -879,7 +879,6 @@
             },
 
             'notification': function () {
-
               var title = _.vsprintf(
                 win.booktype._(message.message, message.message.replace(/_/g, ' ')),
                 message.message_args
@@ -890,6 +889,12 @@
                 [message.username, message.datetime]
               );
               win.booktype.utils.notification(title, messageMeta);
+            },
+
+            'attachment_rename': function () {
+              jquery('#contenteditor img[src="' + message.oldSrc + '"]').each(function (k, v) {
+                jquery(v).attr('src', message.newSrc)
+              })
             }
           };
 

--- a/lib/booktype/apps/edit/templates/edit/panel_media.html
+++ b/lib/booktype/apps/edit/templates/edit/panel_media.html
@@ -55,7 +55,6 @@
     </div>
     <div class="modal-body">
       <form>
-        <p>{% trans "Renaming can produce an issue if this image was inserted into the chapter. You must edit raw html manually to fix a file path." %}</p>
         <input type="hidden" name="attachment" value=""/>
         <input type="text" name="filename" value=""/>.<span></span>
       </form>


### PR DESCRIPTION
Hi @eos87 ,

This is additional feature which makes image renaming for end user more comfortable. 
If image has been inserted into the book (chapters), user still can change image filename. System will change all filenames in entire book and also update another clients (myself=True) chapter's content with new value.

Cheers 🍺 