### PR TITLE
BK-2470 Clarify labels for the section settings

### DIFF
--- a/lib/booktype/apps/edit/static/edit/css/edit.css
+++ b/lib/booktype/apps/edit/static/edit/css/edit.css
@@ -838,7 +838,7 @@ div.bk-image-layout-ui-controls table td.color-caption {
 }
 
 .wizard-section-settings select.toc.form-control {
-  width: 200px;
+  width: 240px;
   margin-bottom: 3px;
   margin-top: 3px;
 }

--- a/lib/booktype/apps/edit/templates/edit/_section_settings_wizard.html
+++ b/lib/booktype/apps/edit/templates/edit/_section_settings_wizard.html
@@ -19,8 +19,8 @@
                     <table class="table table-striped table-condensed">
                         <thead>
                             <th>{% trans "Output Name" %}</th>
-                            <th>{% trans "Show" %}</th>
-                            <th>{% trans "In Table of Contents" %}</th>
+                            <th>{% trans "Show in Output?" %}</th>
+                            <th>{% trans "Show in Table of Contents?" %}</th>
                         </thead>
                         <tbody>
                         {% for opt, label in publish_options_ordered_tuple %}


### PR DESCRIPTION
Also allow more space for translated words in the drop-down menu. Currently, the German translation does not fit well.