### PR TITLE
Update booktypedocs.py

### DIFF
--- a/docs/_ext/booktypedocs.py
+++ b/docs/_ext/booktypedocs.py
@@ -7,9 +7,9 @@ import re
 
 from sphinx import addnodes, __version__ as sphinx_ver
 from sphinx.builders.html import StandaloneHTMLBuilder
-from sphinx.writers.html import SmartyPantsHTMLTranslator
+from sphinx.writers.html import HTMLTranslator
 from sphinx.util.console import bold
-from sphinx.util.compat import Directive
+from docutils.parsers.rst import Directive
 
 # RE for option descriptions without a '--' prefix
 simple_option_desc_re = re.compile(


### PR DESCRIPTION
Readthedocs now runs Sphinx 1.6.x so our docs build fails:
https://readthedocs.org/projects/booktype/builds/7088982/

This config change is required, please see https://github.com/django/django/pull/8515/