### PR TITLE
BK-2484 Fix for name change of psycopg2 package

### DIFF
--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -2,5 +2,5 @@
 
 urllib3[secure]
 requests[security]==2.9.1
-psycopg2
+psycopg2-binary
 BeautifulSoup


### PR DESCRIPTION
Only fixes one of the deprecation warnings, but it works for me on a test instance.