### PR TITLE
BK-2488 More helpful error message when username is too long

### DIFF
--- a/lib/booktype/apps/account/templates/account/register_form.html
+++ b/lib/booktype/apps/account/templates/account/register_form.html
@@ -1,7 +1,7 @@
 {% load i18n %}
 <form id="formregister" register-href="{% url "accounts:signin" %}" register-redirect="{% url "portal:frontpage" %}" onsubmit="return false;" action="#" method="GET">{% csrf_token %}
   <div class="form-group">
-    <input name="username" type="text" class="form-control" placeholder="{% trans "User name" %}"/>
+    <input name="username" type="text" class="form-control" placeholder="{% trans "User name (up to 20 characters)" %}"/>
   </div>
   <div class="form-group">
     <input name="password" type="password" class="form-control" placeholder="{% trans "Password (6 characters at least)" %}" />
@@ -14,18 +14,18 @@
   </div>
 
   <div class="notify" style="padding-top: 5px; padding-bottom: 5px; color: red; font-weight: bold">
-    <div class="missing-username template">{% trans "Missing username!" %}</div>
-    <div class="missing-email template">{% trans "Missing e-mail!" %}</div>
+    <div class="missing-username template">{% trans "Missing user name!" %}</div>
+    <div class="missing-email template">{% trans "Missing email address!" %}</div>
     <div class="missing-password template">{% trans "Missing password!" %}</div>
     <div class="missing-fullname template">{% trans "Please provide your real name." %}</div>
-    <div class="invalid-username template">{% blocktrans %}Username is invalid. Please try a different one. You may use alphanumeric characters and characters ".", "_", "-" (dot, underscore and minus). <br/><br/>Examples:<ul><li>vnazor</li><li>Marin.Drzic</li><li>kamilo_kamili</li></ul>{%   endblocktrans %}</div>
-    <div class="invalid-email template">{% trans "This is not a valid e-mail" %}</div>
-    <div class="password-mismatch template">{% trans "Your passwords dont match. Please try a different one." %}</div>
+    <div class="invalid-username template">{% blocktrans %}User name is too long or invalid. You may use up to 20 alphanumeric characters including ".", "_" and "-" (dot, underscore and minus).{% endblocktrans %}</div>
+    <div class="invalid-email template">{% trans "This is not a valid email address!" %}</div>
+    <div class="password-mismatch template">{% trans "Your passwords don't match. Please try entering them again." %}</div>
     <div class="invalid-password template">{% trans "Password must be 6 characters or more!" %}</div>
     <div class="username-taken template">{% trans "Username already taken. Please try a different one." %}</div>
     <div class="email-taken template">{% trans "Email already taken. Please try a different one." %}</div>
     <div class="unknown-error template">{% trans "Unknown error!" %}</div>
-    <div class="fullname-toolong template">{% trans "Fullname is too long!" %}</div>
+    <div class="fullname-toolong template">{% trans "Full name is too long!" %}</div>
     <div class="clear template"></div>
   </div>
 

--- a/lib/booktype/locale/en/LC_MESSAGES/django.po
+++ b/lib/booktype/locale/en/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Booktype 2.4\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-05-09 13:12+0100\n"
+"POT-Creation-Date: 2018-05-25 12:35+0100\n"
 "PO-Revision-Date: 2015-05-15 11:52+0100\n"
 "Last-Translator: Daniel James <daniel.james@sourcefabric.org>\n"
 "Language-Team: Sourcefabric Localization <contact@sourcefabric.org>\n"
@@ -872,7 +872,7 @@ msgid "Only administrator is allowed to create new accounts at the moment."
 msgstr ""
 
 #: lib/booktype/apps/account/templates/account/register_form.html:4
-msgid "User name"
+msgid "User name (up to 20 characters)"
 msgstr ""
 
 #: lib/booktype/apps/account/templates/account/register_form.html:7
@@ -880,11 +880,11 @@ msgid "Password (6 characters at least)"
 msgstr ""
 
 #: lib/booktype/apps/account/templates/account/register_form.html:17
-msgid "Missing username!"
+msgid "Missing user name!"
 msgstr ""
 
 #: lib/booktype/apps/account/templates/account/register_form.html:18
-msgid "Missing e-mail!"
+msgid "Missing email address!"
 msgstr ""
 
 #: lib/booktype/apps/account/templates/account/register_form.html:19
@@ -897,18 +897,16 @@ msgstr ""
 
 #: lib/booktype/apps/account/templates/account/register_form.html:21
 msgid ""
-"Username is invalid. Please try a different one. You may use alphanumeric "
-"characters and characters \".\", \"_\", \"-\" (dot, underscore and minus). "
-"<br/><br/>Examples:<ul><li>vnazor</li><li>Marin.Drzic</li><li>kamilo_kamili</"
-"li></ul>"
+"User name is too long or invalid. You may use up to 20 alphanumeric "
+"characters including \".\", \"_\" and \"-\" (dot, underscore and minus)."
 msgstr ""
 
 #: lib/booktype/apps/account/templates/account/register_form.html:22
-msgid "This is not a valid e-mail"
+msgid "This is not a valid email address!"
 msgstr ""
 
 #: lib/booktype/apps/account/templates/account/register_form.html:23
-msgid "Your passwords dont match. Please try a different one."
+msgid "Your passwords don't match. Please try entering them again."
 msgstr ""
 
 #: lib/booktype/apps/account/templates/account/register_form.html:24
@@ -924,7 +922,7 @@ msgid "Email already taken. Please try a different one."
 msgstr ""
 
 #: lib/booktype/apps/account/templates/account/register_form.html:28
-msgid "Fullname is too long!"
+msgid "Full name is too long!"
 msgstr ""
 
 #: lib/booktype/apps/account/templates/account/register_form.html:32


### PR DESCRIPTION
Remove example usernames which are not displayed anyway. Also some grammar fixes to strings.