### PR TITLE
BK-2493 Lock ebooklib requirement to latest github master stable commit

### DIFF
--- a/requirements/_base.txt
+++ b/requirements/_base.txt
@@ -14,5 +14,5 @@ django-rest-swagger==2.1.0
 djangorestframework==3.5.3
 Markdown==2.6.7
 django-filter==1.0.0
-Ebooklib==0.16
 GitPython==2.1.8
+-e git+git://github.com/aerkalov/ebooklib.git@855ae481d1a56ddc4ea19643d8d89f4244a0551b#egg=EbookLib


### PR DESCRIPTION
Hi @ride90, this just locks out the requirement to avoid breaking changes issues. This is connected with #880 