### PR TITLE
BK-2391 Sets default `mark_section_as` setting to `mainmatter`

### DIFF
--- a/lib/booktype/apps/edit/models.py
+++ b/lib/booktype/apps/edit/models.py
@@ -1,9 +1,10 @@
 # -*- coding: utf-8 -*-
+import json
 from datetime import date
 from django.db import models
 from django.contrib.auth.models import User
 
-from booki.editor.models import Chapter, Book
+from booki.editor.models import Chapter, Book, BookToc
 from booktype.apps.core.models import Role
 
 
@@ -119,3 +120,21 @@ class ChatMessage(models.Model):
 
     def __str__(self):
         return '{} Message from {} at {}.'.format(self.thread, self.sender, self.datetime)
+
+
+# post user save hook
+def default_section_settings(sender, instance, created, **kwargs):
+    """
+    Django signal that fires when BookToc model is being saved.
+
+    This will only set "mark_section_as" setting to "mainmatter" to
+    newly created Sections
+    """
+
+    SECTION_TYPE = 0
+
+    if created and instance.typeof == SECTION_TYPE:
+        instance.settings = json.dumps({"mark_section_as": "mainmatter"})
+        instance.save()
+
+models.signals.post_save.connect(default_section_settings, sender=BookToc)

--- a/lib/booktype/apps/edit/static/edit/js/booktype/toc.js
+++ b/lib/booktype/apps/edit/static/edit/js/booktype/toc.js
@@ -1294,6 +1294,11 @@
 
               // set mark_section_as as option
               var markAs = settings.mark_section_as;
+
+              // if markAs is not created, we default to mainmatter
+              if (typeof markAs === "undefined")
+                markAs = "mainmatter";
+
               $dialog.find("#id_" + markAs).prop("checked", true);
 
               // set custom mark if any


### PR DESCRIPTION
For new sections this will be set by default. For existent section, saving their settings is required