### PR TITLE
Fix Aloha `linkbooktype` plugin

### DIFF
--- a/lib/booktype/apps/edit/static/edit/js/aloha/plugins/booktype/linkbooktype/lib/linkbooktype-plugin.js
+++ b/lib/booktype/apps/edit/static/edit/js/aloha/plugins/booktype/linkbooktype/lib/linkbooktype-plugin.js
@@ -4,7 +4,6 @@ define(['aloha', 'aloha/plugin', 'jquery',  'jquery19', 'ui/ui', 'booktype', 'un
 
     var $a = null,
       range = null,
-      editable = null,
       selectedLinkDomObj = null;
 
     var getContainerAnchor = function (a) {
@@ -202,6 +201,7 @@ define(['aloha', 'aloha/plugin', 'jquery',  'jquery19', 'ui/ui', 'booktype', 'un
 
             if ($a == null) {
               $a = jQuery('<a/>').prop('href', url).text(title);
+              var editable = Aloha.getEditableById('contenteditor');
               GENTICS.Utils.Dom.removeRange(range);
               GENTICS.Utils.Dom.insertIntoDOM($a, range, editable.obj);
             } else {
@@ -226,7 +226,6 @@ define(['aloha', 'aloha/plugin', 'jquery',  'jquery19', 'ui/ui', 'booktype', 'un
 
         UI.adopt('insertLink', null, {
           click: function () {
-            editable = Aloha.activeEditable;
             range = Aloha.Selection.getRangeObject();
             var a = getContainerAnchor(range.startContainer);
 


### PR DESCRIPTION
Fixes null `editable` on insert error.

This error occurred when the user tried to insert a link *before* clicking on the editor (i.e., immediately after loading a chapter in the editor).