### PR TITLE
Fix Aloha `simpletable` plugin

### DIFF
--- a/lib/booktype/apps/edit/static/edit/js/aloha/plugins/booktype/simpletable/lib/simpletable-plugin.js
+++ b/lib/booktype/apps/edit/static/edit/js/aloha/plugins/booktype/simpletable/lib/simpletable-plugin.js
@@ -326,7 +326,7 @@ define(['aloha', 'aloha/plugin', 'jquery', 'jquery19', 'ui/ui', 'aloha/ephemera'
 
         UI.adopt('inserttable', null, {
           click: function () {
-            var editable = Aloha.activeEditable;
+            var editable = Aloha.getEditableById('contenteditor');
             var range = Aloha.Selection.getRangeObject();
 
             var $dropdown = jQuery19('.contentHeader ul.table-dropdown');


### PR DESCRIPTION
Fixes null `editable` on insert error.

This error occurred when the user tried to insert a table before clicking on the editor (i.e., immediately after loading a chapter in the editor).