### PR TITLE
Make static URLs consistent

### DIFF
--- a/lib/booktypecontrol/forms.py
+++ b/lib/booktypecontrol/forms.py
@@ -103,7 +103,7 @@ class SiteDescriptionForm(BaseControlForm, forms.Form):
 
                 config.set_configuration(
                     'BOOKTYPE_SITE_FAVICON',
-                    '{}/static/{}'.format(settings.BOOKTYPE_URL, rand_name)
+                    '{}{}'.format(settings.STATIC_URL, rand_name)
                 )
 
                 # delete prev icon to avoid garbage


### PR DESCRIPTION
Use `STATIC_URL` instead of `BOOKTYPE_URL/static/`.