### PR TITLE
Remove ADMIN_MEDIA_PREFIX

### DIFF
--- a/lib/booktype/skeleton/base_settings.py.original
+++ b/lib/booktype/skeleton/base_settings.py.original
@@ -119,8 +119,6 @@ GROUP_IMAGE_UPLOAD_DIR = 'group_images/'
 MEDIA_ROOT = DATA_ROOT
 MEDIA_URL = DATA_URL
 
-ADMIN_MEDIA_PREFIX = '{}/media/'.format(BOOKTYPE_URL)
-
 # who gets credited as publisher if not otherwise specified
 DEFAULT_PUBLISHER = "Unknown"
 


### PR DESCRIPTION
This setting has been removed in [Django 1.5](https://docs.djangoproject.com/en/dev/releases/1.5/#django-contrib-admin) and is not used in the project.