### PR TITLE
Fix using persian/arabic titles for book covers meta

### DIFF
--- a/lib/booki/editor/views.py
+++ b/lib/booki/editor/views.py
@@ -15,6 +15,7 @@
 # along with Booktype.  If not, see <http://www.gnu.org/licenses/>.
 
 import json
+import unidecode
 
 from django.shortcuts import render_to_response, render
 from django.core.paginator import Paginator, InvalidPage, EmptyPage
@@ -371,7 +372,7 @@ def upload_cover(request, bookid, version=None):
                 import hashlib
 
                 h = hashlib.sha1()
-                h.update(name)
+                h.update(unidecode.unidecode(name))
                 h.update(request.POST.get('format', ''))
                 h.update(request.POST.get('license', ''))
                 h.update(str(datetime.datetime.now()))

--- a/lib/booktype/apps/edit/views.py
+++ b/lib/booktype/apps/edit/views.py
@@ -147,7 +147,7 @@ def upload_cover(request, bookid, version=None):
 
         h = hashlib.sha1()
         h.update(filename)
-        h.update(title)
+        h.update(unidecode.unidecode(title))
         h.update(str(datetime.datetime.now()))
 
         license = models.License.objects.get(


### PR DESCRIPTION
Fixes using persian/arabic titles for meta data in cover manager.