### PR TITLE
Fix the "Visible to everyone" option

### DIFF
--- a/lib/booktype/apps/account/views.py
+++ b/lib/booktype/apps/account/views.py
@@ -214,7 +214,7 @@ class CreateBookView(LoginRequiredMixin, SecurityMixin, BaseCreateView):
         book.author = data.get('author')
         book.license = license
         book.language = language
-        book.hidden = (data.get('visible_to_everyone', None) == 'off')
+        book.hidden = (data.get('visible_to_everyone', None) != 'on')
         book.description = data.get('description', '')
 
         # STEP 2: Metadata


### PR DESCRIPTION
The selected value was ignored. Newly-created books were always visible to everyone.

The reason is that the value of `data.get('visible_to_everyone', None)` can be either `None` or `'on'`. So it should be compared with `'on'`, not `'off'`.