### PR TITLE
Bump GitPython from 2.1.8 to 2.1.8+ in /requirements

### DIFF
--- a/requirements/_base.txt
+++ b/requirements/_base.txt
@@ -15,4 +15,4 @@ djangorestframework==3.5.3
 Markdown==2.6.7
 django-filter==1.1.0
 Ebooklib==0.16
-GitPython==2.1.8
+GitPython>=2.1.8

--- a/requirements/_base.txt
+++ b/requirements/_base.txt
@@ -1,5 +1,6 @@
 Django>1.11.18,<2.0
-django-compressor==2.2
+django-appconf==1.0.3
+django-compressor==2.4
 celery==4.1.1
 django-celery-results==1.0.1
 Unidecode

--- a/requirements/_base.txt
+++ b/requirements/_base.txt
@@ -1,6 +1,6 @@
 Django>1.11.18,<2.0
-django-appconf==1.0.3
 django-compressor==2.4
+django-appconf==1.0.3
 celery==4.1.1
 django-celery-results==1.0.1
 Unidecode

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -3,4 +3,4 @@
 urllib3[secure]
 requests[security]==2.9.2
 psycopg2-binary
-BeautifulSoup
+beautifulsoup4


### PR DESCRIPTION
Couldn't install because of old version of GitPython.